### PR TITLE
Fix static and media path

### DIFF
--- a/codeskel/templates/cs_django_buildout/buildout/src/+package+/+package+/settings.py_tmpl
+++ b/codeskel/templates/cs_django_buildout/buildout/src/+package+/+package+/settings.py_tmpl
@@ -54,8 +54,8 @@ USE_I18N = True
 STATIC_URL = '/static/'
 MEDIA_URL = '/media/'
 
-STATIC_ROOT = '/home/csmant/${package}/static'
-MEDIA_ROOT = '/home/csmant/${package}/media'
+STATIC_ROOT = '/home/csmant/django/${package}/static'
+MEDIA_ROOT = '/home/csmant/django/${package}/media'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (

--- a/codeskel/templates/cs_django_project/+package+/settings.py_tmpl
+++ b/codeskel/templates/cs_django_project/+package+/settings.py_tmpl
@@ -54,8 +54,8 @@ USE_I18N = True
 STATIC_URL = '/static/'
 MEDIA_URL = '/media/'
 
-STATIC_ROOT = '/home/csmant/${package}/static'
-MEDIA_ROOT = '/home/csmant/${package}/media'
+STATIC_ROOT = '/home/csmant/django/${package}/static'
+MEDIA_ROOT = '/home/csmant/django/${package}/media'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (


### PR DESCRIPTION
Usually we serve django projects under ~/django path
