### PR TITLE
Add staticfiles stuff for development

### DIFF
--- a/HISTORY.TXT
+++ b/HISTORY.TXT
@@ -7,6 +7,7 @@ HISTORY
 
 - Change static and media path in settings.py_tmpl
 - Add pytz to django based templates
+- Add staticfiles stuff on urls.py
 
 1.10.1 (2012/11/14)
 --------------------

--- a/codeskel/templates/cs_django_buildout/buildout/src/+package+/+package+/urls.py_tmpl
+++ b/codeskel/templates/cs_django_buildout/buildout/src/+package+/+package+/urls.py_tmpl
@@ -1,5 +1,6 @@
 from django.conf.urls.defaults import *
 from django.views.generic.simple import direct_to_template
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -13,3 +14,4 @@ urlpatterns = patterns('',
     (r'^admin/', include(admin.site.urls)),
 )
 
+urlpatterns += staticfiles_urlpatterns()

--- a/codeskel/templates/cs_django_project/+package+/urls.py_tmpl
+++ b/codeskel/templates/cs_django_project/+package+/urls.py_tmpl
@@ -1,5 +1,6 @@
 from django.conf.urls.defaults import *
 from django.views.generic.simple import direct_to_template
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -13,3 +14,4 @@ urlpatterns = patterns('',
     (r'^admin/', include(admin.site.urls)),
 )
 
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
On development we use static files to serve static content. This works adding 
from django.contrib.staticfiles.urls import staticfiles_urlpatterns
and 
urlpatterns += staticfiles_urlpatterns()

on urls.py file
